### PR TITLE
feat: check hours for team members

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 Simple Go application for calculating hours logged and logging time in Teamwork.
 
 This app can be used without any dependencies.
-Download latest version from [releases](https://github.com/aarbanas/teamwork-go-scraper/releases) and add `config.json` (check the [config.json-example](https://github.com/aarbanas/teamwork-go-scraper/blob/main/config.json-example)) to the
-same directory where the downloaded binary file is. Than just run on UNIX:
+Here is the [documentation]() on how to setup the app. Than just run on UNIX:
 
 ```bash
 $ ./teamwork-go-scraper
@@ -34,6 +33,7 @@ $ ./teamwork-go-scraper -help
 -l             Enter the logging mode (default: reading logged hours)
 -p             If selected hours will be logged by project id (default: log by task id )
 -n             Non billable hours in log mode (default: isBillable)
+-m             Check time logs for team members
 ```
 
 # Table of Contents

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple Go application for calculating hours logged and logging time in Teamwork.
 
 This app can be used without any dependencies.
-Here is the [documentation]() on how to setup the app. Than just run on UNIX:
+Here is the [documentation](https://github.com/aarbanas/teamwork-go-scraper/tree/main/docu) on how to setup the app. Than just run on UNIX:
 
 ```bash
 $ ./teamwork-go-scraper

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ func main() {
 	includeCroatianHolidays := flag.Bool("h", false, "Use for including Croatian national holidays in the calculations")
 	checkMissingHours := flag.Bool("c", false, "Use for checking if there are some days where hours are not logged")
 	nonBillable := flag.Bool("n", false, "Non billable hours in log mode (default: isBillable)")
-	teamHours := flag.Bool("th", false, "Check time logs for team members")
+	teamHours := flag.Bool("m", false, "Check time logs for team members")
 
 	flag.Parse()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,11 +27,17 @@ func main() {
 	includeCroatianHolidays := flag.Bool("h", false, "Use for including Croatian national holidays in the calculations")
 	checkMissingHours := flag.Bool("c", false, "Use for checking if there are some days where hours are not logged")
 	nonBillable := flag.Bool("n", false, "Non billable hours in log mode (default: isBillable)")
+	teamHours := flag.Bool("th", false, "Check time logs for team members")
 
 	flag.Parse()
 
 	// Validate command-line arguments
 	teamwork.ValidateInputParams(*action, *startDate, *endDate)
+
+	if *teamHours {
+		teamwork.CheckTeamMembersHours(configuration, *includeCroatianHolidays, *startDate, *endDate)
+		os.Exit(0)
+	}
 
 	if *log {
 		teamwork.LogHours(*startDate, *endDate, *startTime, *projectMode, *includeCroatianHolidays, *nonBillable, configuration)
@@ -39,12 +45,16 @@ func main() {
 	}
 
 	// Send request to Teamwork
-	response, responseError := teamwork.GetTimeLogs(*startDate, *endDate, configuration)
-	if responseError != nil {
+	response, err := teamwork.GetTimeLogs(*startDate, *endDate, configuration)
+	if err != nil {
 		os.Exit(1)
 	}
 
 	if *checkMissingHours {
+		if len(response.TimeEntries) == 0 {
+			fmt.Println("No time entries found")
+		}
+
 		missingHours := teamwork.ValidateMissingHours(*response, *includeCroatianHolidays, *startDate, *endDate)
 		if len(missingHours) > 0 {
 			for _, missingHour := range missingHours {

--- a/config.json-example
+++ b/config.json-example
@@ -2,4 +2,5 @@
     "userId": "",
     "apiKey": "",
     "url": ""
+    "userIds": [""]
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Config struct {
-	UserId string `json:"userId"`
-	ApiKey string `json:"apiKey"`
-	Url    string `json:"url"`
+	UserId  string `json:"userId"`
+	ApiKey  string `json:"apiKey"`
+	Url     string `json:"url"`
+	UserIds []string
 }
 
 func LoadConfiguration(file string) Config {

--- a/docu/README.md
+++ b/docu/README.md
@@ -1,0 +1,48 @@
+# How to setup for local usage
+
+## Download binary
+
+Go to the [releases page](https://github.com/aarbanas/teamwork-go-scraper/releases) and download binary specific four your operating system.
+
+1. Windows users - most of todays PC's are using 64-bit processor, which means that `teamwork-go-scraper_0.0.0_windows_amd64.tar.gz` is the correct version.
+2. Mac users just need to take care if they are using M-series of processors than `teamwork-go-scraper_0.0.0_darwin_arm64.tar.gz` is the one, but if you are using old Intel processor, than download the `teamwork-go-scraper_0.0.0_darwin_amd64.tar.gz`
+3. Linux users - same as the Windows users
+
+## Create config.json
+
+In the directory where your binary is downloaded (it is usually `Downloads` folder) create `config.json` file.
+
+For Linux/Mac and Windows WSL users (open terminal):
+
+```shell
+$ cd Downloads
+$ nano config.json
+# or for vim users
+$ vi config.json
+```
+
+For Windows users not using WSL (open cmd):
+
+```powershell
+cd Downloads
+echo. > config.json
+notepad config.json
+```
+
+After you open `config.json` in your new editor, copy the content from [config.json-example](https://github.com/aarbanas/teamwork-go-scraper/blob/main/config.json-example) and paste it in the editor.
+
+### Enter required data to config.json
+
+1. `userId` - In Teamwork open your profile
+   1. Click on profile image (bottom left corner)
+   2. View profile
+   3. Copy the userId from the URL: https://teamwork/app/people/COPY_THIS_VALUE/time
+2. `apiKey` - In Teamwork open edit your details
+   1. Click on profile image (bottom left corner)
+   2. Edit my details
+   3. API & Mobile
+   4. Your API Token (Generate new or Show your token if you already have one)
+3. `url` - The base URL from your teamwork account
+4. `userIds` - enter user ids from all team members you whish to check hours periodically
+
+> Remember to save changes made and you are ready to go.

--- a/teamwork/request.go
+++ b/teamwork/request.go
@@ -23,10 +23,12 @@ type Tag struct {
 
 type Response struct {
 	TimeEntries []struct {
-		HoursDecimal float64   `json:"hoursDecimal"`
-		ProjectID    int       `json:"projectId"`
-		Tags         []Tag     `json:"tags"`
-		Date         time.Time `json:"date"`
+		HoursDecimal  float64   `json:"hoursDecimal"`
+		ProjectID     int       `json:"projectId"`
+		Tags          []Tag     `json:"tags"`
+		Date          time.Time `json:"date"`
+		UserFirstName string    `json:"userFirstName"`
+		UserLastName  string    `json:"userLastName"`
 	} `json:"timeEntries"`
 }
 
@@ -94,10 +96,16 @@ func handler(url string, requestMethod string, apiKey string, requestBody interf
 	return &responseBody, nil
 }
 
-func GetTimeLogs(startDate string, endDate string, configuration config.Config) (*Response, error) {
+func GetTimeLogs(startDate string, endDate string, configuration config.Config, ids ...string) (*Response, error) {
+	var userId string
+	if len(ids) > 0 {
+		userId = ids[0]
+	} else {
+		userId = configuration.UserId
+	}
 
 	// URL
-	url := fmt.Sprintf("%s/projects/api/v2/time.json?page=1&pageSize=50&getTotals=true&userId=%s&fromDate=%s&toDate=%s&sortBy=date&sortOrder=desc&matchAllTags=true", configuration.Url, configuration.UserId, startDate, endDate)
+	url := fmt.Sprintf("%s/projects/api/v2/time.json?page=1&pageSize=50&getTotals=true&userId=%s&fromDate=%s&toDate=%s&sortBy=date&sortOrder=desc&matchAllTags=true", configuration.Url, userId, startDate, endDate)
 
 	responseBody, err := handler(url, "GET", configuration.ApiKey, nil)
 	if err != nil {

--- a/teamwork/teamMembersHours.go
+++ b/teamwork/teamMembersHours.go
@@ -1,0 +1,57 @@
+package teamwork
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aarbanas/teamwork-go-scraper/config"
+)
+
+type UserMissingDates struct {
+	FirstName    string
+	LastName     string
+	MissingDates []string
+}
+
+func (u UserMissingDates) String() string {
+	return fmt.Sprintf("\033[1;31m[%s %s]\033[0m: %v", u.FirstName, u.LastName, u.MissingDates)
+}
+
+func CheckTeamMembersHours(configuration config.Config, includeCroHolidays bool, startDate, endDate string) {
+	var userMissingDates []UserMissingDates
+
+	// Iterate through all user IDs
+	for _, userId := range configuration.UserIds {
+
+		// Get user logged hours
+		timeLogs, err := GetTimeLogs(startDate, endDate, configuration, userId)
+		if err != nil {
+			fmt.Println("Error: ", err)
+			continue
+		}
+
+		if len(timeLogs.TimeEntries) == 0 {
+			fmt.Printf("\033[1;31m[%s]:\033[0m No time entries found\n", userId)
+			continue
+		}
+
+		missingHours := ValidateMissingHours(*timeLogs, includeCroHolidays, startDate, endDate)
+		if len(missingHours) > 0 {
+			userMissingDates = append(userMissingDates, UserMissingDates{FirstName: timeLogs.TimeEntries[0].UserFirstName, LastName: timeLogs.TimeEntries[0].UserLastName})
+			index := len(userMissingDates) - 1
+			for _, missingHour := range missingHours {
+				userMissingDates[index].MissingDates = append(userMissingDates[index].MissingDates, missingHour.Date.Format(time.DateOnly))
+			}
+		}
+	}
+
+	if len(userMissingDates) > 0 {
+		reportOutputStrings := make([]string, len(userMissingDates))
+		for i, user := range userMissingDates {
+			reportOutputStrings[i] = user.String()
+		}
+
+		fmt.Println(strings.Join(reportOutputStrings, ",\n"))
+	}
+}


### PR DESCRIPTION
- Implement logic for checking hours for team members
- Catch and fix `panic: runtime error`
- Extend `GetTimeLogs` to fetch logs for different users